### PR TITLE
Make git depend less on human-readable output

### DIFF
--- a/lib/Module/Release/Git.pm
+++ b/lib/Module/Release/Git.pm
@@ -47,13 +47,13 @@ sub check_vcs {
 
 	$self->_print( "Checking state of Git... " );
 
-	my $git_status = $self->run('git status 2>&1');
+	my $git_status = $self->run('git status -s 2>&1');
 
 	no warnings 'uninitialized';
 
-	my( $branch ) = $git_status =~ /^# On branch (\w+)/;
+	my( $branch ) = $self->run('git rev-parse --abbrev-ref HEAD');
 
-	my $up_to_date = $git_status =~ /working directory clean/m;
+	my $up_to_date = ($git_status eq '');
 
 	$self->_die( "\nERROR: Git is not up-to-date: Can't release files\n\n$git_status\n" )
 		unless $up_to_date;


### PR DESCRIPTION
The Debian version of Git respects the locale, which ends up confusing Git.pm as it looks for "# On branch ..." , where my German localized version of Git outputs "Auf Zweig ..." . The two changes change the following:

1) Use the short status of git

This only outputs a list of pending changes. If that list is not empty, we want to bail.

2) Use `git rev-parse --abbrev-ref HEAD` to find the current branch.

https://stackoverflow.com/questions/6245570/how-to-get-current-branch-name-in-git suggests that is
is the best way of finding the currently active branch.

Thanks for maintaining Module::Release and Module::Release::Git!
