### PR TITLE
Update clean working dir output for recent gits

### DIFF
--- a/lib/Module/Release/Git.pm
+++ b/lib/Module/Release/Git.pm
@@ -51,9 +51,9 @@ sub check_vcs {
 
 	no warnings 'uninitialized';
 
-	my( $branch ) = $git_status =~ /^# On branch (\w+)/;
+	my( $branch ) = $git_status =~ /On branch (\w+)/;
 
-	my $up_to_date = $git_status =~ /working directory clean/m;
+	my $up_to_date = $git_status =~ /working (directory|tree) clean/m;
 
 	$self->_die( "\nERROR: Git is not up-to-date: Can't release files\n\n$git_status\n" )
 		unless $up_to_date;

--- a/t/check_vcs.t
+++ b/t/check_vcs.t
@@ -26,16 +26,17 @@ no warnings 'redefine';
 }
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-{
 # Test when there is nothing left to commit (using the starting $output)
-local $Module::Release::Git::run_output = $Module::Release::Git::fine_output;
+foreach my $try (qw(fine_output clean_output_git_2x)) {
+	no strict 'refs';
+	local $Module::Release::Git::run_output = ${ "Module::Release::Git::$try" };
 
-my $rc = eval { $class->$method() };
-my $at = $@;
+	my $rc = eval { $class->$method() };
+	my $at = $@;
 
-ok( ! $at, "(Nothing left to commit) \$@ undef (good)" );
-ok( $rc, "(Nothing left to commit) returns true (good)" );
-}
+	ok( ! $at, "(Nothing left to commit) \$@ undef (good)" );
+	ok( $rc, "(Nothing left to commit) returns true (good)" );
+	}
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Test when there is a new file
@@ -71,7 +72,7 @@ the test run to try different things.
 
 BEGIN {
 package Module::Release::Git;
-use vars qw( $run_output $fine_output
+use vars qw( $run_output $fine_output $clean_output_git_2x
 	$newfile_output $changedfile_output
 	$untrackedfile_output $combined_output
 	);
@@ -79,6 +80,12 @@ use vars qw( $run_output $fine_output
 $fine_output = <<"HERE";
 # On branch master
 nothing to commit (working directory clean)
+HERE
+
+$clean_output_git_2x = <<"HERE";
+On branch master
+Your branch is up-to-date with 'origin/master'
+nothing to commit, working tree clean
 HERE
 
 no warnings 'redefine';


### PR DESCRIPTION
It turns out that the "# On branch" output got changed to "On branch" in
git-1.5.0 and that the "working directory clean" got changed to "working
tree clean" in git-2.9.1.  This change updates the code to handle the
new output when a recent git is used when using `Module::Release` to
release a module.  The original behaviour is retained and the tests have
been extended to check the newer behaviour.

If the code needs updating in any way, just let me know and I'll update and resubmit the PR.