### PR TITLE
Add method to return list of recent contributors

### DIFF
--- a/lib/Module/Release/Git.pm
+++ b/lib/Module/Release/Git.pm
@@ -6,6 +6,7 @@ use Exporter qw(import);
 
 our @EXPORT = qw(
 	check_vcs vcs_tag vcs_exit make_vcs_tag get_vcs_tag_format
+	get_recent_contributors
 	);
 
 use vars qw($VERSION);
@@ -155,6 +156,26 @@ sub vcs_exit {
 	$self->run( "git push --tags" );
 
 	return 1;
+	}
+
+=item get_recent_contributors()
+
+Return a list of contributors since last release.
+
+=cut
+
+sub get_recent_contributors {
+	my $self = shift;
+
+	chomp( my $last_tagged_commit    = $self->run("git rev-list --tags --max-count=1") );
+	chomp( my @commits_from_last_tag = $self->run("git rev-list $last_tagged_commit..HEAD") );
+	my @authors_since_last_tag =
+		map { qx{git show --no-patch --pretty=format:'%an <%ae>' $_} }
+		@commits_from_last_tag;
+	my %authors = map { $_, 1 } @authors_since_last_tag;
+	my @authors = sort keys %authors;
+
+	return @authors;
 	}
 
 =back


### PR DESCRIPTION
This is the concrete implementation of the stub method of the same name
in `Module::Release`.  It searches for the most recent git tag, finds
the commit corresponding to this tag and then returns author information
for all commits between the HEAD commit and the most recent tag (which
is assumed to also be the tag of the most recent release).

I've manually tested this code and have verified that it works as advertised, although haven't added tests for it explicitly here since I'd either need to override `run()` in several cases or would have to set up a test git environment in order to check everything in an automated way.  This didn't seem to be a large return on investment, hence I've avoided adding automated tests in this PR.  If you wish for tests to be added so that you can accept this PR (and consequently [PR31 in Module::Release](https://github.com/briandfoy/module-release/pull/31), then just let me know and I'll try my best to add tests which exercise the code.